### PR TITLE
feat: SSE + Streamable HTTP transport support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,39 @@ npx mcp-doctor test "your-server-command"
 
 ## Usage
 
+### Local stdio server
+
 ```bash
-# Basic inspection
-mcp-doctor test "npx -y @modelcontextprotocol/server-everything"
-
-# JSON output (for CI pipelines)
-mcp-doctor test --json "node my-server.js"
-
-# Custom timeout (default: 30s per operation)
-mcp-doctor test --timeout 60000 "python my_server.py"
+npx mcp-doctor test "npx -y @modelcontextprotocol/server-everything"
 ```
+
+### Remote server (Streamable HTTP)
+
+```bash
+npx mcp-doctor test https://your-server.example.com/mcp
+```
+
+### Remote server (SSE)
+
+```bash
+npx mcp-doctor test https://your-server.example.com/mcp --transport sse
+```
+
+### Authenticated remote server
+
+```bash
+npx mcp-doctor test https://your-server.example.com/mcp \
+  --header "Authorization: Bearer $TOKEN"
+```
+
+### Options
+
+| Flag | Description |
+|---|---|
+| `--json` | Output results as JSON |
+| `--timeout <ms>` | Per-operation timeout (default 30000) |
+| `--transport <kind>` | Force `stdio`, `sse`, or `http` (auto-detected from target) |
+| `--header <Name: value>` | Add header to remote transport. Repeatable. |
 
 ### Exit codes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-doctor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import ora from "ora";
 import type {
   InspectResult,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 import ora from "ora";
 import type {
   InspectResult,
@@ -16,34 +17,27 @@ import { generateSampleArgs } from "./sample-args.js";
 import { printResult } from "./printer.js";
 
 export async function inspectServer(
-  command: string,
+  transport: Transport,
   options: InspectOptions
 ): Promise<InspectResult> {
   const startTime = Date.now();
-  const parts = command.split(/\s+/);
-  const cmd = parts[0];
-  const args = parts.slice(1);
 
   const spinner = ora("Connecting to MCP server...").start();
 
-  const transport = new StdioClientTransport({
-    command: cmd,
-    args,
-    stderr: "pipe",
-  });
-
   const client = new Client({
     name: "mcp-doctor",
-    version: "1.0.0",
+    version: "0.2.0",
   });
 
-  // Collect stderr for diagnostics
+  // Collect stderr for stdio transports only — remote transports don't have it.
   const stderrChunks: string[] = [];
-  const stderrStream = transport.stderr;
-  if (stderrStream && "on" in stderrStream) {
-    (stderrStream as NodeJS.ReadableStream).on("data", (chunk: Buffer) => {
-      stderrChunks.push(chunk.toString());
-    });
+  if (transport instanceof StdioClientTransport) {
+    const stderrStream = transport.stderr;
+    if (stderrStream && "on" in stderrStream) {
+      (stderrStream as NodeJS.ReadableStream).on("data", (chunk: Buffer) => {
+        stderrChunks.push(chunk.toString());
+      });
+    }
   }
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,48 +2,84 @@
 
 import { Command } from "commander";
 import { inspectServer } from "./client.js";
+import { parseTarget, createTransport } from "./transport.js";
+import type { TransportKind } from "./types.js";
 
 const program = new Command();
 
 program
   .name("mcp-doctor")
-  .description("One command to diagnose your MCP server")
-  .version("0.1.0");
+  .description("One command to diagnose your MCP server (stdio, SSE, or Streamable HTTP)")
+  .version("0.2.0");
 
 program
   .command("test")
   .description("Connect to an MCP server and run a full inspection")
   .argument(
-    "<command>",
-    'The MCP server start command (e.g. "npx -y @modelcontextprotocol/server-everything")'
+    "<target>",
+    'MCP server target. A command (e.g. "npx -y @modelcontextprotocol/server-everything") for stdio, or a URL (e.g. "https://example.com/mcp") for remote servers.'
   )
   .option("--json", "Output results as JSON", false)
   .option("--timeout <ms>", "Timeout per operation in milliseconds", "30000")
-  .action(async (command: string, opts: { json: boolean; timeout: string }) => {
-    try {
-      const result = await inspectServer(command, {
-        json: opts.json,
-        timeout: parseInt(opts.timeout, 10),
-      });
+  .option(
+    "--transport <kind>",
+    "Force transport: stdio | sse | http (auto-detected from target by default)"
+  )
+  .option(
+    "--header <header>",
+    'Header for remote transports, "Name: value". Repeatable.',
+    (value: string, prev: string[] = []) => [...prev, value],
+    [] as string[]
+  )
+  .action(
+    async (
+      target: string,
+      opts: {
+        json: boolean;
+        timeout: string;
+        transport?: string;
+        header: string[];
+      }
+    ) => {
+      try {
+        if (
+          opts.transport &&
+          !["stdio", "sse", "http"].includes(opts.transport)
+        ) {
+          throw new Error(
+            `Invalid --transport "${opts.transport}". Expected stdio, sse, or http.`
+          );
+        }
 
-      // Exit with non-zero if any checks failed
-      const { score } = result;
-      const allPassed =
-        score.toolsCallable === score.toolsTotal &&
-        score.resourcesReadable === score.resourcesTotal &&
-        score.promptsGettable === score.promptsTotal &&
-        score.schemaErrors === 0;
+        const spec = parseTarget(target, {
+          transport: opts.transport as TransportKind | undefined,
+          headers: opts.header,
+        });
+        const transport = createTransport(spec);
 
-      if (!allPassed) {
+        const result = await inspectServer(transport, {
+          json: opts.json,
+          timeout: parseInt(opts.timeout, 10),
+        });
+
+        const { score } = result;
+        const allPassed =
+          score.toolsCallable === score.toolsTotal &&
+          score.resourcesReadable === score.resourcesTotal &&
+          score.promptsGettable === score.promptsTotal &&
+          score.schemaErrors === 0;
+
+        if (!allPassed) {
+          process.exit(1);
+        }
+      } catch (error) {
+        console.error(
+          "Error:",
+          error instanceof Error ? error.message : error
+        );
         process.exit(1);
       }
-    } catch (error) {
-      console.error(
-        "Error:",
-        error instanceof Error ? error.message : error
-      );
-      process.exit(1);
     }
-  });
+  );
 
 program.parse();

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -54,3 +54,37 @@ describe("parseTarget", () => {
     );
   });
 });
+
+import { createTransport } from "./transport.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+
+describe("createTransport", () => {
+  it("builds a StdioClientTransport for stdio specs", () => {
+    const t = createTransport({
+      kind: "stdio",
+      command: "echo",
+      args: ["hi"],
+    });
+    expect(t).toBeInstanceOf(StdioClientTransport);
+  });
+
+  it("builds an SSEClientTransport for sse specs", () => {
+    const t = createTransport({
+      kind: "sse",
+      url: new URL("https://example.com/mcp"),
+      headers: {},
+    });
+    expect(t).toBeInstanceOf(SSEClientTransport);
+  });
+
+  it("builds a StreamableHTTPClientTransport for http specs", () => {
+    const t = createTransport({
+      kind: "http",
+      url: new URL("https://example.com/mcp"),
+      headers: {},
+    });
+    expect(t).toBeInstanceOf(StreamableHTTPClientTransport);
+  });
+});

--- a/src/transport.test.ts
+++ b/src/transport.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseTarget } from "./transport.js";
+
+describe("parseTarget", () => {
+  it("treats http:// targets as streamable HTTP by default", () => {
+    const spec = parseTarget("http://localhost:3000/mcp", {});
+    expect(spec.kind).toBe("http");
+    if (spec.kind === "http" || spec.kind === "sse") {
+      expect(spec.url.href).toBe("http://localhost:3000/mcp");
+      expect(spec.headers).toEqual({});
+    }
+  });
+
+  it("treats https:// targets as streamable HTTP by default", () => {
+    const spec = parseTarget("https://api.example.com/mcp", {});
+    expect(spec.kind).toBe("http");
+  });
+
+  it("honors --transport sse override for URL targets", () => {
+    const spec = parseTarget("https://api.example.com/mcp", { transport: "sse" });
+    expect(spec.kind).toBe("sse");
+  });
+
+  it("parses command strings as stdio targets", () => {
+    const spec = parseTarget("npx -y @modelcontextprotocol/server-everything", {});
+    expect(spec.kind).toBe("stdio");
+    if (spec.kind === "stdio") {
+      expect(spec.command).toBe("npx");
+      expect(spec.args).toEqual(["-y", "@modelcontextprotocol/server-everything"]);
+    }
+  });
+
+  it("parses headers array into record", () => {
+    const spec = parseTarget("https://x/mcp", {
+      headers: ["Authorization: Bearer abc", "X-Trace: 1"],
+    });
+    if (spec.kind === "http") {
+      expect(spec.headers).toEqual({
+        Authorization: "Bearer abc",
+        "X-Trace": "1",
+      });
+    }
+  });
+
+  it("throws if --transport stdio is given with a URL", () => {
+    expect(() => parseTarget("https://x/mcp", { transport: "stdio" })).toThrow(
+      /stdio.*URL/i
+    );
+  });
+
+  it("throws if --transport http is given with a command", () => {
+    expect(() => parseTarget("npx server", { transport: "http" })).toThrow(
+      /http.*URL/i
+    );
+  });
+});

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,4 +1,8 @@
 import type { TargetSpec, TransportKind } from "./types.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
 
 export interface ParseTargetOptions {
   transport?: TransportKind;
@@ -52,4 +56,33 @@ function parseHeaders(raw: string[]): Record<string, string> {
     out[name] = value;
   }
   return out;
+}
+
+export function createTransport(spec: TargetSpec): Transport {
+  if (spec.kind === "stdio") {
+    return new StdioClientTransport({
+      command: spec.command,
+      args: spec.args,
+      stderr: "pipe",
+    });
+  }
+
+  const requestInit: RequestInit =
+    Object.keys(spec.headers).length > 0 ? { headers: spec.headers } : {};
+
+  if (spec.kind === "sse") {
+    return new SSEClientTransport(spec.url, {
+      requestInit,
+      eventSourceInit:
+        Object.keys(spec.headers).length > 0
+          ? {
+              fetch: (input, init) =>
+                fetch(input, { ...init, headers: { ...init?.headers, ...spec.headers } }),
+            }
+          : undefined,
+    });
+  }
+
+  // kind === "http"
+  return new StreamableHTTPClientTransport(spec.url, { requestInit });
 }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,8 +1,8 @@
 import type { TargetSpec, TransportKind } from "./types.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp";
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 export interface ParseTargetOptions {
   transport?: TransportKind;

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,55 @@
+import type { TargetSpec, TransportKind } from "./types.js";
+
+export interface ParseTargetOptions {
+  transport?: TransportKind;
+  headers?: string[];
+}
+
+export function parseTarget(
+  target: string,
+  opts: ParseTargetOptions
+): TargetSpec {
+  const isUrl = /^https?:\/\//i.test(target);
+
+  if (isUrl) {
+    if (opts.transport === "stdio") {
+      throw new Error(
+        "--transport stdio is incompatible with a URL target. Pass a command instead."
+      );
+    }
+    const kind: "sse" | "http" = opts.transport === "sse" ? "sse" : "http";
+    return {
+      kind,
+      url: new URL(target),
+      headers: parseHeaders(opts.headers ?? []),
+    };
+  }
+
+  if (opts.transport === "sse" || opts.transport === "http") {
+    throw new Error(
+      `--transport ${opts.transport} requires a URL target (http:// or https://).`
+    );
+  }
+
+  const parts = target.split(/\s+/).filter(Boolean);
+  return {
+    kind: "stdio",
+    command: parts[0],
+    args: parts.slice(1),
+  };
+}
+
+function parseHeaders(raw: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of raw) {
+    const idx = h.indexOf(":");
+    if (idx === -1) {
+      throw new Error(`Invalid --header "${h}". Expected "Name: value".`);
+    }
+    const name = h.slice(0, idx).trim();
+    const value = h.slice(idx + 1).trim();
+    if (!name) throw new Error(`Invalid --header "${h}". Missing name.`);
+    out[name] = value;
+  }
+  return out;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,3 +82,19 @@ export interface InspectOptions {
   json: boolean;
   timeout: number;
 }
+
+export type TransportKind = "stdio" | "sse" | "http";
+
+export interface StdioTargetSpec {
+  kind: "stdio";
+  command: string;
+  args: string[];
+}
+
+export interface HttpTargetSpec {
+  kind: "sse" | "http";
+  url: URL;
+  headers: Record<string, string>;
+}
+
+export type TargetSpec = StdioTargetSpec | HttpTargetSpec;


### PR DESCRIPTION
## Summary

- Add SSE and Streamable HTTP transport support alongside existing stdio (closes #1)
- Auto-detect transport from target: URLs → Streamable HTTP, commands → stdio
- New CLI flags: `--transport stdio|sse|http` (override) and `--header "Name: value"` (repeatable, for auth)
- Fully backward compatible — existing `mcp-doctor test "npx server"` works unchanged

## Changes

| File | What |
|---|---|
| `src/types.ts` | `TransportKind`, `TargetSpec` union types |
| `src/transport.ts` | `parseTarget()` + `createTransport()` factory |
| `src/transport.test.ts` | 10 unit tests for parser + factory |
| `src/client.ts` | `inspectServer()` now accepts any `Transport` |
| `src/index.ts` | CLI wired with URL support + new flags |
| `package.json` | Version bump to 0.2.0 |
| `README.md` | Docs for remote server usage |

## Test plan

- [x] 21/21 unit tests passing (10 new transport tests)
- [x] TypeScript typecheck clean
- [x] Build clean
- [x] Smoke test: stdio server end-to-end (npx @modelcontextprotocol/server-everything)
- [x] Smoke test: CLI validation rejects `--transport stdio` with URL target

🤖 Generated with [Claude Code](https://claude.com/claude-code)