### PR TITLE
docs(readme): cross-link MCP Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ Marketplace listing: [github.com/marketplace/actions/mcp-probe-mcp-server-health
 
 The official [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a GUI for interactive exploration — point, click, see what a server returns. `mcp-probe` is a CLI for automated, repeatable diagnosis — every tool/resource/prompt called automatically, pass/fail scorecard out, exit code in. Use Inspector when you're exploring; use `mcp-probe` in CI, in pre-publish checks, or when you want a shareable scorecard of someone else's server.
 
+## Ecosystem
+
+- **[MCP Registry](https://mcp-registry-dh5.pages.dev)** — Cross-source catalog of MCP servers (~6,900 indexed across 6 upstream lists) with quality scores powered by `mcp-probe`. CLI: `npm i -g @incultnitollc/mcpr`. Built by Incultnito LLC.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds new `## Ecosystem` section to README.md cross-linking sister project **MCP Registry** (`@incultnitollc/mcpr`)
- Placed between `## Compared to MCP Inspector` and `## Development` for natural reading flow
- Cross-link goes live before Buffer-scheduled mcp-registry v1 launch posts fire Friday 2026-05-29

## Why

mcp-probe and mcp-registry are sister projects from Incultnito LLC. The registry uses `mcp-probe` to score the ~6,900 MCP servers it indexes across 6 upstream lists. Cross-linking lets visitors discover the catalog and CLI.

## Test plan

- [x] Diff is additive only (4 lines), no existing content modified
- [x] Section heading uses `##` to match document hierarchy
- [x] Link target `https://mcp-registry-dh5.pages.dev` is the current LIVE CF Pages URL
- [x] CLI install command `npm i -g @incultnitollc/mcpr` matches published scope on npm
- [ ] Maintainer review

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>